### PR TITLE
feat(#8): implement list all players endpoint

### DIFF
--- a/lib/two-rooms-and-a-boom-stack.ts
+++ b/lib/two-rooms-and-a-boom-stack.ts
@@ -17,6 +17,7 @@ export class TwoRoomsAndABoomStack extends Stack {
     createEndpoint(this, 'setActiveCards');
     createEndpoint(this, 'clearActiveCards');
     createEndpoint(this, 'registerNewPlayer');
+    createEndpoint(this, 'listAllPlayers');
   }
 }
 

--- a/src/dao/game/index.ts
+++ b/src/dao/game/index.ts
@@ -1,2 +1,3 @@
+export {listAllPlayers} from './listAllPlayers';
 export {resetActiveCards} from './resetActiveCards';
 export {setActiveCards} from './setActiveCards';

--- a/src/dao/game/listAllPlayers.ts
+++ b/src/dao/game/listAllPlayers.ts
@@ -1,0 +1,13 @@
+import {getClient} from '../client';
+
+type ListAllPlayers = {playerid: string; username: string};
+
+async function listAllPlayers(): Promise<ListAllPlayers[]> {
+  const client = await getClient();
+  const result = await client.query(
+    'SELECT playerid, username FROM two_rooms_and_a_boom.player;',
+  );
+  return result.rows;
+}
+
+export {listAllPlayers};

--- a/src/dao/game/test/listAllPlayers.test.ts
+++ b/src/dao/game/test/listAllPlayers.test.ts
@@ -1,0 +1,46 @@
+import {getClient} from '../../client';
+import {listAllPlayers} from '../listAllPlayers';
+
+const CLIENT_MOCK = {
+  connect: jest.fn(),
+  query: jest.fn(),
+  end: jest.fn(),
+};
+jest.mock('../../client', () => ({
+  getClient: jest.fn().mockImplementation(() => CLIENT_MOCK),
+}));
+
+describe('listAllPlayers', () => {
+  beforeEach(() => {
+    CLIENT_MOCK.query.mockResolvedValue({});
+  });
+
+  it('should call getClient function', async () => {
+    await listAllPlayers();
+    expect(getClient).toHaveBeenCalled();
+  });
+
+  it('should call Client with query function', async () => {
+    await listAllPlayers();
+    expect(CLIENT_MOCK.query).toHaveBeenCalledWith(
+      'SELECT playerid, username FROM two_rooms_and_a_boom.player;',
+    );
+  });
+
+  it('should return list of players on successful DB matches', async () => {
+    const testPlayers = [
+      {playerid: 'abc-123', username: 'test-player-1'},
+      {playerid: 'def-456', username: 'test-player-2'},
+      {playerid: 'ghi-789', username: 'test-player-3'},
+    ];
+    CLIENT_MOCK.query.mockResolvedValue({rows: testPlayers});
+    const result = await listAllPlayers();
+    expect(result).toStrictEqual(testPlayers);
+  });
+
+  it('should return empty list if nothing matches in DB', async () => {
+    CLIENT_MOCK.query.mockResolvedValue({rows: []});
+    const result = await listAllPlayers();
+    expect(result).toStrictEqual([]);
+  });
+});

--- a/src/functions/listAllPlayers/index.ts
+++ b/src/functions/listAllPlayers/index.ts
@@ -1,0 +1,8 @@
+import {listAllPlayers} from '../../dao';
+
+async function handler() {
+  const players = await listAllPlayers();
+  return {statusCode: 200, body: {players}};
+}
+
+export {handler};

--- a/src/functions/listAllPlayers/test/index.test.ts
+++ b/src/functions/listAllPlayers/test/index.test.ts
@@ -1,0 +1,33 @@
+import {handler} from '..';
+import {listAllPlayers} from '../../../dao';
+
+jest.mock('../../../dao', () => ({
+  listAllPlayers: jest.fn(),
+}));
+
+describe('clearActiveCards', () => {
+  beforeEach(() => {
+    jest.mocked(listAllPlayers).mockResolvedValue([]);
+  });
+
+  it('should call resetActiveCards dao function once', async () => {
+    await handler();
+    expect(listAllPlayers).toHaveBeenCalled();
+  });
+
+  it('should return list of players on a successful run', async () => {
+    const testPlayers = [
+      {playerid: 'abc-123', username: 'test-player-1'},
+      {playerid: 'def-456', username: 'test-player-2'},
+      {playerid: 'ghi-789', username: 'test-player-3'},
+    ];
+    jest.mocked(listAllPlayers).mockResolvedValue(testPlayers);
+    const {body} = await handler();
+    expect(body).toStrictEqual({players: testPlayers});
+  });
+
+  it('should return statusCode 200 on a successful run', async () => {
+    const {statusCode} = await handler();
+    expect(statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
This endpoint will allow the game host to view all the players who are in the game and eventually will allow the host to manage the game lobby by being able to players.