### PR TITLE
feat(#7): create check credentials endpoint

### DIFF
--- a/lib/two-rooms-and-a-boom-stack.ts
+++ b/lib/two-rooms-and-a-boom-stack.ts
@@ -23,6 +23,7 @@ export class TwoRoomsAndABoomStack extends Stack {
     createEndpoint(this, 'endGame');
     createEndpoint(this, 'getPlayerDetails');
     createEndpoint(this, 'deletePlayer');
+    createEndpoint(this, 'checkPlayerCredentials');
 
     const getCardImageFunction = createEndpoint(this, 'getCardImageUrl');
     getCardImageFunction.addToRolePolicy(

--- a/src/dao/player/deletePlayer.ts
+++ b/src/dao/player/deletePlayer.ts
@@ -3,7 +3,7 @@ import {getClient} from '../client';
 async function deletePlayer(playerId: string): Promise<boolean> {
   const client = await getClient();
   const result = await client.query(
-    'DELETE FROM two_rooms_and_a_boom.player g WHERE g.playerid = $1',
+    'DELETE FROM two_rooms_and_a_boom.player WHERE playerid = $1',
     [playerId],
   );
   console.log({...result});

--- a/src/dao/player/test/deletePlayer.test.ts
+++ b/src/dao/player/test/deletePlayer.test.ts
@@ -19,7 +19,7 @@ describe('deletePlayer', () => {
   it('should call client with get player details statement', async () => {
     await deletePlayer(MOCK_PLAYER_ID);
     expect(CLIENT_MOCK.query).toHaveBeenCalledWith(
-      'DELETE FROM two_rooms_and_a_boom.player g WHERE g.playerid = $1',
+      'DELETE FROM two_rooms_and_a_boom.player WHERE playerid = $1',
       [MOCK_PLAYER_ID],
     );
   });

--- a/src/functions/checkPlayerCredentials/index.ts
+++ b/src/functions/checkPlayerCredentials/index.ts
@@ -1,5 +1,5 @@
 import {APIGatewayProxyEvent} from 'aws-lambda';
-import {checkExistingCredentials, createNewPlayer} from '../../dao';
+import {checkExistingCredentials} from '../../dao';
 
 async function handler({body}: APIGatewayProxyEvent) {
   if (!body) {
@@ -9,11 +9,9 @@ async function handler({body}: APIGatewayProxyEvent) {
   const {username} = JSON.parse(body);
   const existingPlayer = await checkExistingCredentials(username);
   if (existingPlayer) {
-    return {statusCode: 409, body: 'player with that username already exists'};
+    return {statusCode: 200, body: JSON.stringify(existingPlayer)};
   }
-
-  const newPlayer = await createNewPlayer(username);
-  return {statusCode: 201, body: JSON.stringify(newPlayer)};
+  return {statusCode: 404, body: 'Player does not exist'};
 }
 
 export {handler};

--- a/src/functions/checkPlayerCredentials/test/index.test.ts
+++ b/src/functions/checkPlayerCredentials/test/index.test.ts
@@ -1,0 +1,41 @@
+import {handler} from '..';
+import {checkExistingCredentials} from '../../../dao';
+
+import type {APIGatewayProxyEvent} from 'aws-lambda';
+
+jest.mock('../../../dao', () => ({
+  checkExistingCredentials: jest.fn(),
+}));
+
+const TEST_USERNAME = 'test-user';
+const MOCK_USER_ID = '123-abc';
+const MOCK_API_GATEWAY_PROXY_EVENT = {
+  body: JSON.stringify({username: TEST_USERNAME}),
+} as unknown as APIGatewayProxyEvent;
+
+describe('checkPlayerCredentials', () => {
+  beforeEach(() => {
+    jest
+      .mocked(checkExistingCredentials)
+      .mockResolvedValue({id: MOCK_USER_ID, username: TEST_USERNAME});
+  });
+
+  it('should return status code 200', async () => {
+    const {statusCode} = await handler(MOCK_API_GATEWAY_PROXY_EVENT);
+    expect(statusCode).toStrictEqual(200);
+  });
+
+  it('should return existing user details', async () => {
+    const {body} = await handler(MOCK_API_GATEWAY_PROXY_EVENT);
+    expect(JSON.parse(body)).toStrictEqual({
+      id: MOCK_USER_ID,
+      username: TEST_USERNAME,
+    });
+  });
+
+  it('should return status code 404 if player does not exist', async () => {
+    jest.mocked(checkExistingCredentials).mockResolvedValue(null);
+    const {statusCode} = await handler(MOCK_API_GATEWAY_PROXY_EVENT);
+    expect(statusCode).toStrictEqual(404);
+  });
+});

--- a/src/functions/registerNewPlayer/test/index.test.ts
+++ b/src/functions/registerNewPlayer/test/index.test.ts
@@ -1,11 +1,11 @@
 import {randomUUID} from 'crypto';
 
 import {handler} from '..';
-import {checkExistingCredentials, createNewPlayer} from '../../../dao/player';
+import {checkExistingCredentials, createNewPlayer} from '../../../dao';
 
 import type {APIGatewayProxyEvent} from 'aws-lambda';
 
-jest.mock('../../../dao/player', () => ({
+jest.mock('../../../dao', () => ({
   checkExistingCredentials: jest.fn(),
   createNewPlayer: jest.fn(),
 }));
@@ -41,7 +41,7 @@ describe('registerNewPlayer', () => {
     });
   });
 
-  describe('when returning existing player credentials', () => {
+  describe('when player with username already exists', () => {
     const mockUserId = randomUUID();
 
     beforeEach(() => {
@@ -50,17 +50,9 @@ describe('registerNewPlayer', () => {
         .mockResolvedValue({id: mockUserId, username: TEST_USERNAME});
     });
 
-    it('should return status code 200', async () => {
+    it('should return status code 409', async () => {
       const {statusCode} = await handler(MOCK_API_GATEWAY_PROXY_EVENT);
-      expect(statusCode).toStrictEqual(200);
-    });
-
-    it('should return existing user details', async () => {
-      const {body} = await handler(MOCK_API_GATEWAY_PROXY_EVENT);
-      expect(JSON.parse(body)).toStrictEqual({
-        id: mockUserId,
-        username: TEST_USERNAME,
-      });
+      expect(statusCode).toStrictEqual(409);
     });
   });
 });


### PR DESCRIPTION
Checking existing player:
<img width="846" height="669" alt="Screenshot 2026-03-02 at 22 03 51" src="https://github.com/user-attachments/assets/d96c8e1f-a019-4aae-a5f3-136e192bea06" />

Attempting to create a player with the same name:
<img width="846" height="669" alt="Screenshot 2026-03-02 at 22 04 42" src="https://github.com/user-attachments/assets/32561606-209a-4179-87e6-b72964a9c228" />

